### PR TITLE
knc now uses poll() instead of select()

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -5,5 +5,6 @@ AM_CPPFLAGS = -DKNC_VERSION_STRING=\"1.12\"
 bin_PROGRAMS = knc
 
 knc_SOURCES = knc.c gssstdio.c
+knc_CPPFLAGS = $(AM_CPPFLAGS) $(WFLAGS)
 
 man_MANS = knc.1

--- a/bin/gssstdio.c
+++ b/bin/gssstdio.c
@@ -453,7 +453,8 @@ read_packet(int fd, gss_buffer_t buf, int timeout, int first)
 	int	  ret;
 
 	static uint32_t		len = 0;
-	static char		len_buf[4];
+	static uint32_t		nlen = 0;
+	static char *		len_buf = (char *)&nlen;
 	static int		len_buf_pos = 0;
 	static char *		tmpbuf = 0;
 	static uint32_t		tmpbuf_pos = 0;
@@ -498,7 +499,7 @@ read_packet(int fd, gss_buffer_t buf, int timeout, int first)
 		return -2;
 
 	/* We have the complete length */
-	len = ntohl(*(uint32_t *)len_buf);
+	len = ntohl(nlen);
 
 	/*
 	 * We make sure recvd length is reasonable, allowing for some

--- a/bin/gssstdio.c
+++ b/bin/gssstdio.c
@@ -364,7 +364,7 @@ gstd_read(void *the_tok, char *buf, size_t length)
 	 */
 
 	length = MIN(length, tok->gstd_inbuf.length - bufpos);
-	memcpy(buf, tok->gstd_inbuf.value + bufpos, length);
+	memcpy(buf, (char *)tok->gstd_inbuf.value + bufpos, length);
 	tok->gstd_inbufpos = bufpos + length;
 	LOG(LOG_DEBUG, ("read %d bytes", length));
 	return length;

--- a/bin/gssstdio.c
+++ b/bin/gssstdio.c
@@ -472,7 +472,9 @@ read_packet(int fd, gss_buffer_t buf, int timeout, int first)
 		    timeout);
 
 		if (ret == -1) {
-			if (errno == EINTR || errno == EAGAIN)
+			if (   errno == EINTR
+			    || errno == EAGAIN
+			    || errno == EWOULDBLOCK)
 				return -2;
 
 			LOG(LOG_ERR, ("%s", strerror(errno)));
@@ -522,7 +524,7 @@ read_packet(int fd, gss_buffer_t buf, int timeout, int first)
 	ret = timed_read(fd, tmpbuf + tmpbuf_pos, len - tmpbuf_pos, timeout);
 	if (ret == -1) {
 
-		if (errno == EINTR || errno == EAGAIN)
+		if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
 			return -2;
 
 		LOG(LOG_ERR, ("%s", strerror(errno)));

--- a/bin/gssstdio.c
+++ b/bin/gssstdio.c
@@ -244,8 +244,7 @@ again:
 
 
 void *
-gstd_initiate(const char *hostname, const char *service, const char *princ,
-	      int fd)
+gstd_initiate(const char *hostname, const char *service, const char *princ, int fd)
 {
 	struct gstd_tok	*tok;
 	gss_ctx_id_t	ctx = GSS_C_NO_CONTEXT;
@@ -272,7 +271,7 @@ gstd_initiate(const char *hostname, const char *service, const char *princ,
 			return NULL;
 		type = GSS_C_NT_HOSTBASED_SERVICE;
 	} else {
-		name.value = (char *) princ;
+		name.value = (void *)(uintptr_t)princ;
 		name.length = strlen(princ);
 		type = (gss_OID) GSS_C_NO_OID;
 	}

--- a/bin/gssstdio.c
+++ b/bin/gssstdio.c
@@ -163,10 +163,7 @@ gstd_get_mech(gss_OID mech_oid)
 	OM_uint32	min;
 #endif
 	gss_buffer_desc	buf;
-	unsigned char   *bufp;
-	unsigned char   nibble;
 	char		*ret;
-	size_t		i, k;
 
 	if (mech_oid->length == sizeof(KNC_KRB5_MECH_OID) - 1 &&
 	    memcmp(mech_oid->elements, KNC_KRB5_MECH_OID,

--- a/bin/gssstdio.h
+++ b/bin/gssstdio.h
@@ -71,7 +71,7 @@ struct gstd_tok {
 	int		gstd_fd;	/* file descriptor for the stream */
 };
 
-int	 gstd_read(void *, char *, int);
+ssize_t	 gstd_read(void *, char *, size_t);
 int	 gstd_close(void *);
 
 void	*gstd_accept(int, char **, char **, char **);
@@ -81,8 +81,8 @@ void	 gstd_release_context(void *);
 
 void gstd_error(int, int, const char *);
 
-int	 readn(int, void *, ssize_t);
-int	 writen(int, const void *, ssize_t);
+ssize_t	 readn(int, void *, ssize_t);
+ssize_t	 writen(int, const void *, ssize_t);
 
 #define GSTD_MAXPACKETCONTENTS	65536	/* max contents of a single payload */
 

--- a/bin/knc.1
+++ b/bin/knc.1
@@ -111,9 +111,6 @@ increment debug level (specify multiple times for increased debugging).
 bind to address
 .Ar bind_address
 when in server mode (default is INADDR_ANY).
-.It Fl S Ar path
-connect to the named Unix domain socket upon accepting a connection rather
-than launching a program.
 .It Fl f
 don't fork when in server mode (useful for debugging).
 .It Fl c
@@ -136,7 +133,6 @@ set the ident of syslog messages instead of the default of argv[0].
 .It Fl w
 in server mode, start as an inetd wait service.
 That is, expect stdin to be a listening socket and process requests on it.
-.Nm
 .It Fl M Ar max
 in server mode, the maximum number of connexions to process before exiting.
 .It Fl N Ar fd
@@ -156,7 +152,7 @@ server.
 .It Fl S Ar sun_path
 in server mode, connect to the UNIX domain socket specified by
 .Ar sun_path
-rather than run a program.
+upon accepting a connection rather than launching a program.
 .It Fl T Ar max_time
 in server mode, the maximum time to process requests.
 .El

--- a/bin/knc.1
+++ b/bin/knc.1
@@ -371,11 +371,13 @@ The astute reader will point out that
 .Em [A,E]
 is not a socket in the general case, and that
 .Xr shutdown 2
-fails on non-sockets.  This is why
+fails on non-sockets.
 .Nm
-.Em actually
-invokes an internal routine
-.Fn shutdown_or_close
+invokes
+.Xr close 2
+if
+.Xr shutdown 2
+fails,
 which handles the non-socket case appropriately.
 .Sh EXAMPLE
 A simple loopback test can be performed by invoking the server as:

--- a/bin/knc.c
+++ b/bin/knc.c
@@ -881,6 +881,7 @@ write_local_buffer(work_t *work)
 			 */
 			LOG(LOG_DEBUG, ("write got EPIPE"));
 
+			work->local_buffer.in_valid = 0;
 			work->local_buffer.out_valid = 0;
 			return 0;
 		} else {
@@ -992,6 +993,7 @@ write_network_buffer(work_t *work)
 			 */
 			LOG(LOG_DEBUG, ("gstd_write got EPIPE"));
 
+			work->network_buffer.in_valid = 0;
 			work->network_buffer.out_valid = 0;
 			return 0;
 		} else {

--- a/bin/knc.c
+++ b/bin/knc.c
@@ -1814,6 +1814,7 @@ do_listener(int listener, int argc, char **argv)
 	struct sockaddr_storage	 sa;
 	int			 fd;
 	int			 num_connections = 0;
+	int			 timeout = 60000; /* wake every 60s to reap */
 	time_t			 endtime = 0;
 	socklen_t		 client_len;
 	work_t			*work;
@@ -1833,8 +1834,15 @@ do_listener(int listener, int argc, char **argv)
 
 	while (!dienow) {
 		/* Exit if we have exceeded our maximum time limit */
-		if (endtime && time(NULL) > endtime)
-			break;
+		if (endtime) {
+			time_t now = time(NULL);
+			if (now > endtime)
+				break;
+
+			timeout = (endtime - now) * 1000 + 1000;
+			/* wake every 60 sec to check for children to reap() */
+			if (timeout > 60000) timeout = 60000;
+		}
 
 		/*
 		 * If we have exceeded the maximum number of allowed
@@ -1850,7 +1858,7 @@ do_listener(int listener, int argc, char **argv)
 		num_children -= reap();
 
 		/* poll() is interruptable, even by sigaction w/ SA_RESTART */
-		if (poll(pfds, 1, 60000) <= 0) { /* wake every 60s to reap() */
+		if (poll(pfds, 1, timeout) <= 0) {
 			continue;
 		}
 

--- a/bin/knc.c
+++ b/bin/knc.c
@@ -1191,12 +1191,12 @@ move_data(work_t *work)
 					LOG(LOG_DEBUG, ("EOF on network side."
 						        " Queueing shutdown"));
 
-					shut_nread_lwrite = 1;
+					shut_nread_lwrite |= 1;
 
 					network_active = 0;
 
 					if (prefs.no_half_close) {
-						shut_nwrite_lread = 1;
+						shut_nwrite_lread |= 1;
 						local_active = 0;
 					}
 				} else if (mret < 0)
@@ -1211,12 +1211,12 @@ move_data(work_t *work)
 						        "read. Queueing "
 						        "shutdown"));
 
-					shut_nwrite_lread = 1;
+					shut_nwrite_lread |= 1;
 
 					local_active = 0;
 
 					if (prefs.no_half_close) {
-						shut_nread_lwrite = 1;
+						shut_nread_lwrite |= 1;
 						network_active = 0;
 					}
 				} else if (mret < 0)
@@ -1240,7 +1240,7 @@ move_data(work_t *work)
 					LOG(LOG_DEBUG, ("EPIPE on network-side "
 						        "write. Queueing "
 						        "shutdown"));
-					shut_nwrite_lread = 1;
+					shut_nwrite_lread |= 1;
 				}
 			}
 
@@ -1260,7 +1260,7 @@ move_data(work_t *work)
 					LOG(LOG_DEBUG, ("EPIPE on local-side "
 						        "write. Queueing "
 						        "shutdown"));
-					shut_nread_lwrite = 1;
+					shut_nread_lwrite |= 1;
 				}
 			}
 		} else if (ret == 0) {

--- a/bin/knc.c
+++ b/bin/knc.c
@@ -807,7 +807,7 @@ move_local_to_network_buffer(work_t *work)
 		/* EOF */
 		return 0;
 	} else if (work->network_buffer.in_len < 0) {
-		if (errno == EINTR || errno == EAGAIN)
+		if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
 			return 1; /* retry later (do not return <= 0) */
 		if (errno == ECONNRESET)
 			return 0; /* Treat as EOF */
@@ -861,7 +861,7 @@ write_local_buffer(work_t *work)
 		    work->local_buffer.out_len);
 
 	if (len < 0) {
-		if (errno == EINTR || errno == EAGAIN)
+		if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
 			return 1; /* retry later (do not return <= 0) */
 		if (errno == EPIPE) {
 			/*
@@ -972,7 +972,7 @@ write_network_buffer(work_t *work)
 		    work->network_buffer.out_len);
 
 	if (len < 0) {
-		if (errno == EINTR || errno == EAGAIN)
+		if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
 			return 1; /* retry later (do not return <= 0) */
 		if (errno == EPIPE) {
 			/*
@@ -1168,7 +1168,9 @@ move_data(work_t *work)
 					    sizeof(errbuf) - 1);
 				switch (mret) {
 				case -1:
-					if (errno == EINTR || errno == EAGAIN)
+					if (   errno == EINTR
+					    || errno == EAGAIN
+					    || errno == EWOULDBLOCK)
 						break;
 					/*FALLTHROUGH*/
 				case 0:
@@ -1805,7 +1807,9 @@ do_listener(int listener, int argc, char **argv)
 		if ((fd = accept(listener, (struct sockaddr *)&sa,
 				 &client_len)) < 0) {
 
-			if ((errno != EINTR) && (errno != EAGAIN))
+			if (   errno != EINTR
+			    && errno != EAGAIN
+			    && errno != EWOULDBLOCK)
 				LOG_ERRNO(LOG_WARNING, ("failed to accept"));
 
 			work_free(work);

--- a/bin/knc.c
+++ b/bin/knc.c
@@ -1819,13 +1819,6 @@ do_listener(int listener, int argc, char **argv)
 		/* Reap any children who've died */
 		num_children -= reap();
 
-		if ((work = (work_t *)malloc(sizeof(work_t))) == NULL) {
-			LOG(LOG_CRIT, ("malloc of work structure failed"));
-			return 0;
-		}
-
-		work_init(work);
-
 		client_len = sizeof(sa);
 		if ((fd = accept(listener, (struct sockaddr *)&sa,
 				 &client_len)) < 0) {
@@ -1835,11 +1828,15 @@ do_listener(int listener, int argc, char **argv)
 			    && errno != EWOULDBLOCK)
 				LOG_ERRNO(LOG_WARNING, ("failed to accept"));
 
-			work_free(work);
-			free(work);
-
 			continue;
 		}
+
+		if ((work = (work_t *)malloc(sizeof(work_t))) == NULL) {
+			LOG(LOG_CRIT, ("malloc of work structure failed"));
+			return 0;
+		}
+
+		work_init(work);
 
 		sockaddr_2str(work, (struct sockaddr *)&sa, client_len);
 		num_connections++;

--- a/bin/knc.c
+++ b/bin/knc.c
@@ -747,6 +747,12 @@ handshake(work_t *work)
 	return 0;
 }
 
+/*
+ * Returns:
+ *		>0	No error (or temporary error)
+ *		0	EOF
+ *		-1	Unrecoverable error
+ */
 int
 move_network_to_local_buffer(work_t *work)
 {
@@ -770,13 +776,19 @@ move_network_to_local_buffer(work_t *work)
 		LOG(LOG_ERR, ("gstd_read error"));
 		return -1;
 	case -2:
-		return 1;
+		return 1; /* retry later (do not return <= 0) */
 	}
 
 	work->local_buffer.in_valid = 1;
 	return work->local_buffer.in_len;
 }
 
+/*
+ * Returns:
+ *		>0	No error (or temporary error)
+ *		0	EOF
+ *		-1	Unrecoverable error
+ */
 int
 move_local_to_network_buffer(work_t *work)
 {
@@ -795,6 +807,8 @@ move_local_to_network_buffer(work_t *work)
 		/* EOF */
 		return 0;
 	} else if (work->network_buffer.in_len < 0) {
+		if (errno == EINTR || errno == EAGAIN)
+			return 1; /* retry later (do not return <= 0) */
 		if (errno == ECONNRESET)
 			return 0; /* Treat as EOF */
 
@@ -808,9 +822,9 @@ move_local_to_network_buffer(work_t *work)
 
 /*
  * Returns:
- *		1	Buffer completely transmitted
- *		0	Buffer partially transmitted, please call again
- *		-1	Unrecoverable error
+ *		>0	No error (or temporary error)
+ *		0	Unrecoverable error (EPIPE)
+ *		-1	Unrecoverable error (other)
  */
 int
 write_local_buffer(work_t *work)
@@ -846,7 +860,9 @@ write_local_buffer(work_t *work)
 		    &(work->local_buffer.out[work->local_buffer.out_pos]),
 		    work->local_buffer.out_len);
 
-	if (len < 0 && ((errno != EINTR) && (errno != EAGAIN))) {
+	if (len < 0) {
+		if (errno == EINTR || errno == EAGAIN)
+			return 1; /* retry later (do not return <= 0) */
 		if (errno == EPIPE) {
 			/*
 			 * It's possible that exec'd programs (or the
@@ -891,9 +907,9 @@ write_local_buffer(work_t *work)
 
 /*
  * Returns:
- *		1	Buffer completely transmitted
- *		0	Buffer partially transmitted, please call again
- *		-1	Unrecoverable error
+ *		>0	No error (or temporary error)
+ *		0	Unrecoverable error (EPIPE)
+ *		-1	Unrecoverable error (other)
  */
 int
 write_network_buffer(work_t *work)
@@ -955,7 +971,9 @@ write_network_buffer(work_t *work)
 		    &(work->network_buffer.out[work->network_buffer.out_pos]),
 		    work->network_buffer.out_len);
 
-	if (len < 0 && ((errno != EINTR) && (errno != EAGAIN))) {
+	if (len < 0) {
+		if (errno == EINTR || errno == EAGAIN)
+			return 1; /* retry later (do not return <= 0) */
 		if (errno == EPIPE) {
 			/*
 			 * It's possible that exec'd programs (or the
@@ -1149,9 +1167,11 @@ move_data(work_t *work)
 				mret = read(work->local_err, errbuf,
 					    sizeof(errbuf) - 1);
 				switch (mret) {
-				case 0:
-					/*FALLTHROUGH*/
 				case -1:
+					if (errno == EINTR || errno == EAGAIN)
+						break;
+					/*FALLTHROUGH*/
+				case 0:
 					/* just close it on errors or EOF. */
 					close(work->local_err);
 					work->local_err = -1;

--- a/bin/knc.c
+++ b/bin/knc.c
@@ -1471,12 +1471,10 @@ emit_key_value(work_t * work, const char * const key,
 	 * own key:value pair.
 	 *
 	 * On the receiver, poor data handling may allow embedded NULs
-	 * to cause trouble.
-	 *
-	 * Disallow both.
+	 * to cause trouble, but since these are C-strings, NUL will truncate.
 	 */
-	if (strpbrk(value, "\n\000") != NULL) {
-		LOG(LOG_CRIT, ("embedded newline or NUL in value '%s' for key "
+	if (strchr(value, '\n') != NULL) {
+		LOG(LOG_CRIT, ("embedded newline in value '%s' for key "
 			       "'%s'.  connection terminated.", value, key));
 		return 0;
 	}

--- a/bin/knc.c
+++ b/bin/knc.c
@@ -338,7 +338,6 @@ int
 main(int argc, char **argv)
 {
 	int	c;
-	int	ret;
 
 	/* initialize preferences */
 	memset(&prefs, 0, sizeof(prefs));	/* not strictly necessary... */
@@ -610,7 +609,6 @@ connect_host_inner(const char *domain, const char *service)
 	struct addrinfo	*res0;
 	int		 ret;
 	int		 s = -1;
-	char		 buf[256];
 
 	LOG(LOG_DEBUG, ("connecting to (%s, %s)", service, domain));
 	if (!service) {
@@ -1715,7 +1713,6 @@ do_inetd_nowait(int argc, char **argv)
 	struct sockaddr_storage	ss;
 	work_t			work;
 	socklen_t               len;
-	int			fd;
 	int			ret;
  
 	work_init(&work);
@@ -1783,7 +1780,6 @@ int
 do_listener(int listener, int argc, char **argv)
 {
 	struct sockaddr_storage	 sa;
-	uint16_t		 port;
 	int			 fd;
 	int			 num_children = 0;
 	int			 num_connections = 0;

--- a/bin/knc.c
+++ b/bin/knc.c
@@ -1805,7 +1805,11 @@ do_listener(int listener, int argc, char **argv)
 	if (prefs.max_time)
 		endtime = time(NULL) + prefs.max_time;
 
-	while (1) {
+	while (!dienow) {
+		/* Exit if we have exceeded our maximum time limit */
+		if (endtime && time(NULL) > endtime)
+			break;
+
 		/*
 		 * If we have exceeded the maximum number of allowed
 		 * child processes, we sleep here.
@@ -1870,18 +1874,9 @@ do_listener(int listener, int argc, char **argv)
 		work_free(work);
 		free(work);
 
-		/*
-		 * If we've processed the maximum number of connections,
-		 * or have exceeded our maximum time limit, we exit...
-		 */
+		/* Exit if we've processed the maximum number of connections */
 		if (prefs.max_connections &&
 		    num_connections >= prefs.max_connections)
-			break;
-
-		if (endtime && time(NULL) > endtime)
-			break;
-
-		if (dienow)
 			break;
 	}
 

--- a/bin/knc.c
+++ b/bin/knc.c
@@ -1604,7 +1604,7 @@ do_work(work_t *work, int argc, char **argv)
 			work->local_in = STDOUT_FILENO;
 			work->local_out = STDIN_FILENO;
 		} else if (!launch_program(work, argc, argv))
-			exit(1);
+			return 0;
 	}
 
 	/* Use non-blocking local writes I/O */
@@ -1700,7 +1700,7 @@ launch_program(work_t *work, int argc, char **argv)
 		/* If we get here, the exec failed */
 
 		LOG_ERRNO(LOG_ERR, ("exec of %s failed", argv[0]));
-		exit(1);
+		_exit(1);
 	}
 
 	/* parent */
@@ -1725,7 +1725,7 @@ fork_and_do_work(work_t *work, int listener, int argc, char **argv)
 	} else if (pid == 0) {
 		/* child */
 		close(listener);
-		exit(!do_work(work, argc, argv));
+		_exit(!do_work(work, argc, argv));
 	}
 
 	LOG(LOG_DEBUG, ("parent returning to accept"));
@@ -1793,7 +1793,7 @@ fork_and_do_unix_socket(work_t *work, int listener)
 	} else if (pid == 0) {
 		/* child */
 		close(listener);
-		exit(!do_unix_socket(work));
+		_exit(!do_unix_socket(work));
 	}
 
 	LOG(LOG_DEBUG, ("parent returning to accept"));

--- a/bin/knc.h
+++ b/bin/knc.h
@@ -57,13 +57,13 @@ extern prefs_t prefs;
 
 /* Simple input/output buffering */
 typedef struct write_buffer_s {
-	char			in[GSTD_MAXPACKETCONTENTS];
 	char			in_valid;
-	size_t			in_len;
-	char			out[2 * GSTD_MAXPACKETCONTENTS + 4];
 	char			out_valid;
 	int			out_pos;
+	size_t			in_len;
 	size_t			out_len;
+	char			in[GSTD_MAXPACKETCONTENTS];
+	char			out[2 * GSTD_MAXPACKETCONTENTS + 4];
 } write_buffer_t;
 
 

--- a/lib/libknc.c
+++ b/lib/libknc.c
@@ -215,14 +215,14 @@ int debug = 0;
 			debug_printf x ;	\
 		}				\
 	} while (0/*CONSTCOND*/)
+
+static void	debug_printf(knc_ctx, const char *, ...)
+    __attribute__((__format__(__printf__, 2, 3)));
 #else
 #define DEBUG(x)
 #endif
 
 /* Local function declarations */
-
-static void	debug_printf(knc_ctx, const char *, ...)
-    __attribute__((__format__(__printf__, 2, 3)));
 
 static void		 destroy_stream(stream);
 static stream_bit	 get_stream_bit(stream);


### PR DESCRIPTION
- poll with POLLRDHUP when POLLRDUP is supported
  - save POLLRDHUP if received, cease reading once socket buffers empty
  - poll without timeout (-1; INFTIM) when POLLRDHUP is supported
- check for and return if not waiting for any events (sockets closed)
- check that shut_nread_lwrite, shut_nwrite_lread run no more than once
- propagate effects of close() if shutdown() fails
- retry (later) on read() or write() if EINTR or EAGAIN